### PR TITLE
Refactor the kafka-boom-boom to leverage confluent ubi8 images with tc

### DIFF
--- a/Dockerfile.kafka
+++ b/Dockerfile.kafka
@@ -1,0 +1,8 @@
+FROM confluentinc/cp-kafka:latest-ubi8
+
+USER root
+
+RUN yum install -y \
+     libmnl \
+     which
+RUN rpm -i --nodeps --nosignature http://vault.centos.org/8.1.1911/BaseOS/x86_64/os/Packages/iproute-tc-4.18.0-15.el8.x86_64.rpm

--- a/Dockerfile.zookeeper
+++ b/Dockerfile.zookeeper
@@ -1,0 +1,8 @@
+FROM confluentinc/cp-zookeeper:latest-ubi8
+
+USER root
+
+RUN yum install -y \
+     libmnl \
+     which
+RUN rpm -i --nodeps --nosignature http://vault.centos.org/8.1.1911/BaseOS/x86_64/os/Packages/iproute-tc-4.18.0-15.el8.x86_64.rpm

--- a/hierarchical/docker-compose.yaml
+++ b/hierarchical/docker-compose.yaml
@@ -1,7 +1,9 @@
 version: "3"
 services:
   zookeeper-1:
-    image: confluentinc/cp-zookeeper
+    build:
+      context: ../
+      dockerfile: Dockerfile.zookeeper
     hostname: zookeeper-1
     environment:
       ZOOKEEPER_SERVER_ID: "1"
@@ -10,7 +12,9 @@ services:
       ZOOKEEPER_GROUPS: 1:2:3;4:5:6
 
   zookeeper-2:
-    image: confluentinc/cp-zookeeper
+    build:
+      context: ../
+      dockerfile: Dockerfile.zookeeper
     hostname: zookeeper-2
     environment:
       ZOOKEEPER_SERVER_ID: "2"
@@ -19,7 +23,9 @@ services:
       ZOOKEEPER_SERVERS: zookeeper-1:2888:3888;zookeeper-2:2888:3888;zookeeper-3:2888:3888;zookeeper-4:2888:3888;zookeeper-5:2888:3888;zookeeper-6:2888:3888
 
   zookeeper-3:
-    image: confluentinc/cp-zookeeper
+    build:
+      context: ../
+      dockerfile: Dockerfile.zookeeper
     hostname: zookeeper-3
     environment:
       ZOOKEEPER_SERVER_ID: "3"
@@ -28,7 +34,9 @@ services:
       ZOOKEEPER_GROUPS: 1:2:3;4:5:6
 
   zookeeper-4:
-    image: confluentinc/cp-zookeeper
+    build:
+      context: ../
+      dockerfile: Dockerfile.zookeeper
     hostname: zookeeper-4
     environment:
       ZOOKEEPER_SERVER_ID: "4"
@@ -37,7 +45,9 @@ services:
       ZOOKEEPER_GROUPS: 1:2:3;4:5:6
 
   zookeeper-5:
-    image: confluentinc/cp-zookeeper
+    build:
+      context: ../
+      dockerfile: Dockerfile.zookeeper
     hostname: zookeeper-5
     environment:
       ZOOKEEPER_SERVER_ID: "5"
@@ -46,7 +56,9 @@ services:
       ZOOKEEPER_GROUPS: 1:2:3;4:5:6
 
   zookeeper-6:
-    image: confluentinc/cp-zookeeper
+    build:
+      context: ../
+      dockerfile: Dockerfile.zookeeper
     hostname: zookeeper-6
     environment:
       ZOOKEEPER_SERVER_ID: "6"
@@ -55,7 +67,9 @@ services:
       ZOOKEEPER_GROUPS: 1:2:3;4:5:6
 
   kafka-1:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-1
     depends_on:
       - zookeeper-1
@@ -68,7 +82,9 @@ services:
       KAFKA_BROKER_ID: "1"
 
   kafka-2:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-2
     depends_on:
       - zookeeper-1
@@ -81,7 +97,9 @@ services:
       KAFKA_BROKER_ID: "2"
 
   kafka-3:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-3
     depends_on:
       - zookeeper-1
@@ -94,7 +112,9 @@ services:
       KAFKA_BROKER_ID: "3"
 
   kafka-4:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-4
     depends_on:
       - zookeeper-1

--- a/scenario-1/docker-compose.yaml
+++ b/scenario-1/docker-compose.yaml
@@ -1,13 +1,17 @@
 version: "2"
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper
+    build:
+      context: ../
+      dockerfile: Dockerfile.zookeeper
     hostname: zookeeper
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
 
   kafka-1:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-1
     depends_on:
       - zookeeper
@@ -18,7 +22,9 @@ services:
       KAFKA_BROKER_ID: "1"
 
   kafka-2:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-2
     depends_on:
       - zookeeper
@@ -29,7 +35,9 @@ services:
       KAFKA_BROKER_ID: "2"
 
   kafka-3:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-3
     depends_on:
       - zookeeper
@@ -38,4 +46,3 @@ services:
       KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka-3:9092"
       KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: "1"
       KAFKA_BROKER_ID: "3"
-

--- a/scenario-2/docker-compose.yaml
+++ b/scenario-2/docker-compose.yaml
@@ -1,14 +1,18 @@
 version: "3"
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper
+    build:
+      context: ../
+      dockerfile: Dockerfile.zookeeper
     hostname: zookeeper
     environment:
       zk_id: "1"
       ZOOKEEPER_CLIENT_PORT: 2181
 
   kafka-1:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-1
     depends_on:
       - zookeeper
@@ -20,7 +24,9 @@ services:
       KAFKA_BROKER_ID: "1"
 
   kafka-2:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-2
     depends_on:
       - zookeeper
@@ -32,7 +38,9 @@ services:
       KAFKA_LOG4J_ROOT_LOGLEVEL: "TRACE"
 
   kafka-3:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-3
     depends_on:
       - zookeeper
@@ -44,7 +52,9 @@ services:
       KAFKA_LOG4J_ROOT_LOGLEVEL: "TRACE"
 
   kafka-4:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-4
     depends_on:
       - zookeeper

--- a/scenario-3/docker-compose.yaml
+++ b/scenario-3/docker-compose.yaml
@@ -1,7 +1,9 @@
 version: "3"
 services:
   zookeeper-1:
-    image: confluentinc/cp-zookeeper
+    build:
+      context: ../
+      dockerfile: Dockerfile.zookeeper
     hostname: zookeeper-1
     environment:
       ZOOKEEPER_SERVER_ID: "1"
@@ -9,7 +11,9 @@ services:
       ZOOKEEPER_SERVERS: zookeeper-1:2888:3888;zookeeper-2:2888:3888;zookeeper-3:2888:3888
 
   zookeeper-2:
-    image: confluentinc/cp-zookeeper
+    build:
+      context: ../
+      dockerfile: Dockerfile.zookeeper
     hostname: zookeeper-2
     environment:
       ZOOKEEPER_SERVER_ID: "2"
@@ -17,7 +21,9 @@ services:
       ZOOKEEPER_SERVERS: zookeeper-1:2888:3888;zookeeper-2:2888:3888;zookeeper-3:2888:3888
 
   zookeeper-3:
-    image: confluentinc/cp-zookeeper
+    build:
+      context: ../
+      dockerfile: Dockerfile.zookeeper
     hostname: zookeeper-3
     environment:
       ZOOKEEPER_SERVER_ID: "3"
@@ -25,7 +31,9 @@ services:
       ZOOKEEPER_SERVERS: ${ZOOKEEPER_SERVERS}
 
   kafka-1:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-1
     depends_on:
       - zookeeper-1
@@ -38,7 +46,9 @@ services:
       KAFKA_BROKER_ID: "1"
 
   kafka-2:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-2
     depends_on:
       - zookeeper-1
@@ -51,7 +61,9 @@ services:
       KAFKA_BROKER_ID: "2"
 
   kafka-3:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-3
     depends_on:
       - zookeeper-1
@@ -64,7 +76,9 @@ services:
       KAFKA_BROKER_ID: "3"
 
   kafka-4:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-4
     depends_on:
       - zookeeper-1

--- a/scenario-4/docker-compose.yaml
+++ b/scenario-4/docker-compose.yaml
@@ -1,7 +1,9 @@
 version: "3"
 services:
   zookeeper-1:
-    image: confluentinc/cp-zookeeper
+    build:
+      context: ../
+      dockerfile: Dockerfile.zookeeper
     hostname: zookeeper-1
     environment:
       ZOOKEEPER_SERVER_ID: "1"
@@ -9,7 +11,9 @@ services:
       ZOOKEEPER_SERVERS: zookeeper-1:2888:3888;zookeeper-2:2888:3888;zookeeper-3:2888:3888
 
   zookeeper-2:
-    image: confluentinc/cp-zookeeper
+    build:
+      context: ../
+      dockerfile: Dockerfile.zookeeper
     hostname: zookeeper-2
     environment:
       ZOOKEEPER_SERVER_ID: "2"
@@ -17,7 +21,9 @@ services:
       ZOOKEEPER_SERVERS: zookeeper-1:2888:3888;zookeeper-2:2888:3888;zookeeper-3:2888:3888
 
   zookeeper-3:
-    image: confluentinc/cp-zookeeper
+    build:
+      context: ../
+      dockerfile: Dockerfile.zookeeper
     hostname: zookeeper-3
     environment:
       ZOOKEEPER_SERVER_ID: "3"
@@ -25,7 +31,9 @@ services:
       ZOOKEEPER_SERVERS: zookeeper-1:2888:3888;zookeeper-2:2888:3888;zookeeper-3:2888:3888
 
   kafka-1:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-1
     depends_on:
       - zookeeper-1
@@ -38,7 +46,9 @@ services:
       KAFKA_BROKER_ID: "1"
 
   kafka-2:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-2
     depends_on:
       - zookeeper-1
@@ -51,7 +61,9 @@ services:
       KAFKA_BROKER_ID: "2"
 
   kafka-3:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-3
     depends_on:
       - zookeeper-1
@@ -64,7 +76,9 @@ services:
       KAFKA_BROKER_ID: "3"
 
   kafka-4:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-4
     depends_on:
       - zookeeper-1

--- a/scenario-5/docker-compose.yaml
+++ b/scenario-5/docker-compose.yaml
@@ -1,7 +1,9 @@
 version: "3"
 services:
   zookeeper-1:
-    image: confluentinc/cp-zookeeper
+    build:
+      context: ../
+      dockerfile: Dockerfile.zookeeper
     hostname: zookeeper-1
     environment:
       ZOOKEEPER_SERVER_ID: "1"
@@ -9,7 +11,9 @@ services:
       ZOOKEEPER_SERVERS: zookeeper-1:2888:3888;zookeeper-2:2888:3888;zookeeper-3:2888:3888
 
   zookeeper-2:
-    image: confluentinc/cp-zookeeper
+    build:
+      context: ../
+      dockerfile: Dockerfile.zookeeper
     hostname: zookeeper-2
     environment:
       ZOOKEEPER_SERVER_ID: "2"
@@ -17,7 +21,9 @@ services:
       ZOOKEEPER_SERVERS: zookeeper-1:2888:3888;zookeeper-2:2888:3888;zookeeper-3:2888:3888
 
   zookeeper-3:
-    image: confluentinc/cp-zookeeper
+    build:
+      context: ../
+      dockerfile: Dockerfile.zookeeper
     hostname: zookeeper-3
     environment:
       ZOOKEEPER_SERVER_ID: "3"
@@ -25,7 +31,9 @@ services:
       ZOOKEEPER_SERVERS: zookeeper-1:2888:3888;zookeeper-2:2888:3888;zookeeper-3:2888:3888
 
   kafka-1:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-1
     depends_on:
       - zookeeper-1
@@ -39,7 +47,9 @@ services:
       KAFKA_BROKER_RACK: rack-a
 
   kafka-2:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-2
     depends_on:
       - zookeeper-1
@@ -53,7 +63,9 @@ services:
       KAFKA_BROKER_RACK: rack-a
 
   kafka-3:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-3
     depends_on:
       - zookeeper-1
@@ -67,7 +79,9 @@ services:
       KAFKA_BROKER_RACK: rack-b
 
   kafka-4:
-    image: confluentinc/cp-kafka
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-4
     depends_on:
       - zookeeper-1

--- a/zookeeper-disconnect/docker-compose.yaml
+++ b/zookeeper-disconnect/docker-compose.yaml
@@ -1,14 +1,18 @@
 version: "3"
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:${CONFLUENT_VERSION}
+    build:
+      context: ../
+      dockerfile: Dockerfile.zookeeper
     hostname: zookeeper
     environment:
       zk_id: "1"
       ZOOKEEPER_CLIENT_PORT: 2181
 
   kafka-1:
-    image: confluentinc/cp-kafka:${CONFLUENT_VERSION}
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-1
     depends_on:
       - zookeeper
@@ -20,7 +24,9 @@ services:
       KAFKA_BROKER_ID: "1"
 
   kafka-2:
-    image: confluentinc/cp-kafka:${CONFLUENT_VERSION}
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-2
     depends_on:
       - zookeeper
@@ -32,7 +38,9 @@ services:
       KAFKA_LOG4J_ROOT_LOGLEVEL: "TRACE"
 
   kafka-3:
-    image: confluentinc/cp-kafka:${CONFLUENT_VERSION}
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-3
     depends_on:
       - zookeeper
@@ -44,7 +52,9 @@ services:
       KAFKA_LOG4J_ROOT_LOGLEVEL: "TRACE"
 
   kafka-4:
-    image: confluentinc/cp-kafka:${CONFLUENT_VERSION}
+    build:
+      context: ../
+      dockerfile: Dockerfile.kafka
     hostname: kafka-4
     depends_on:
       - zookeeper


### PR DESCRIPTION
Recent confluent images are based on ubi8 that doesn't include tc anymore.

We need to rebuild those images to be able to : 

- install tc
- run as root (because tc requires permissions) 

I would not recommend the second step for production usage but since this is made just to "break things" it's fine.
The alternative would be to change the scripts to leverage docker run with --privileged options, but I thought that would be much more painful.

Let me know if you have any comments.