### PR TITLE
Fixed issues with latest versions of Docker and Confluent

### DIFF
--- a/Dockerfile.kafka
+++ b/Dockerfile.kafka
@@ -1,8 +1,9 @@
-FROM confluentinc/cp-kafka:latest-ubi8
+FROM confluentinc/cp-kafka:6.2.4-1-ubi8
 
 USER root
 
 RUN yum install -y \
      libmnl \
+     iptables \
      which
 RUN rpm -i --nodeps --nosignature http://vault.centos.org/8.1.1911/BaseOS/x86_64/os/Packages/iproute-tc-4.18.0-15.el8.x86_64.rpm

--- a/Dockerfile.zookeeper
+++ b/Dockerfile.zookeeper
@@ -1,8 +1,9 @@
-FROM confluentinc/cp-zookeeper:latest-ubi8
+FROM confluentinc/cp-zookeeper:6.2.4-1-ubi8
 
 USER root
 
 RUN yum install -y \
      libmnl \
+     iptables \
      which
 RUN rpm -i --nodeps --nosignature http://vault.centos.org/8.1.1911/BaseOS/x86_64/os/Packages/iproute-tc-4.18.0-15.el8.x86_64.rpm

--- a/utils/utils.sh
+++ b/utils/utils.sh
@@ -25,7 +25,7 @@ log() {
 
 container_to_name() {
     container=$1
-    echo "${PWD##*/}_${container}_1"
+    echo "${PWD##*/}-${container}-1"
 }
 
 container_to_ip() {


### PR DESCRIPTION
Find more detailes in the individual commit messages:

- [fixed container_to_name to work with latest Docker conventions](https://github.com/Dabz/kafka-boom-boom/commit/cb520d7a353f1e0430197b2d9d383428e248ed57)
- [anchor a specific version for Confluent images instead of using lates…](https://github.com/Dabz/kafka-boom-boom/commit/eadc2e1cbd8046cb472d329d8ef6d463825a35bb)